### PR TITLE
Update `HACKER_SCHOOL_URL` to reflect domain change

### DIFF
--- a/HackerSchool/src/main/java/knaps/hacker/school/utils/Constants.java
+++ b/HackerSchool/src/main/java/knaps/hacker/school/utils/Constants.java
@@ -13,7 +13,7 @@ public final class Constants {
     public static final String ACTION_LOADING_START = "knaps.hacker.school.LOADING_START";
     public static final String ACTION_LOADING_ENDED = "knaps.hacker.school.LOADING_ENDED";
 
-    public final static String HACKER_SCHOOL_URL = "https://www.hackerschool.com";
+    public final static String HACKER_SCHOOL_URL = "https://www.recurse.com";
 
     public static final String OAUTH = "/oauth";
     public final static String OAUTH_AUTHORIZE = HACKER_SCHOOL_URL + OAUTH + "/authorize";


### PR DESCRIPTION
We thought we could switch to recurse.com without breaking existing OAuth clients, but that turned out not to be the case. =( Really sorry!

This updates `HACKER_SCHOOL_URL` to reflect our new domain.

(We haven't tested this, but we're pretty sure that this should be the only change required.)
